### PR TITLE
Fixes for cvs writer

### DIFF
--- a/io_framework/csv_file_to_db.py
+++ b/io_framework/csv_file_to_db.py
@@ -1,22 +1,24 @@
 from influxdb import InfluxDBClient
-from resources.config import RESOURCES_DIR
 import progressbar
 
-def csv_file_to_db(host, port, username, password, database, filename):
+
+def csv_file_to_db(host, port, username, password, database, filepath, measurement,
+                   label_to_use, field_name_to_use, drop_db):
     client = InfluxDBClient(host, port, username, password, database)
-    client.drop_database(database)
+    if drop_db:
+        client.drop_database(database)
     client.create_database(database)
     value_index = 1
-    itterator = 0
-    widgets=[progressbar.Percentage(), progressbar.Bar(), progressbar.ETA()]
+    iterator = 0
+    widgets = [progressbar.Percentage(), progressbar.Bar(), progressbar.ETA()]
     print("Starting to write cvs data to database: {}".format(database))
-    with open(filename) as f:
+    with open(filepath) as f:
         data = [x.split(',') for x in f.readlines()]
         bar = progressbar.ProgressBar(widgets=widgets, max_value=len(data)-1).start()
         labels = data[0]
         data.pop(0)
         for label in labels:
-            if label == 'avg_hrcrx_max_byt':
+            if label == label_to_use:
                 value_index = labels.index(label)
         for metric in data:
             try:
@@ -26,23 +28,26 @@ def csv_file_to_db(host, port, username, password, database, filename):
                 byte_value = int(round(float(string_value)))
             except ValueError:
                 print("Cannot transform string {} to integer".format(metric[value_index].rstrip()))
-                byte_value = '0'
+                continue
             json_body = [
                 {
-                    "measurement": "per15min",
+                    "measurement": measurement,
                     "time": metric[0],
                     "fields": {
-                        "avg_hrcrx_max_byt": byte_value
+                        field_name_to_use: byte_value
                     }
                 }
             ]
             client.write_points(json_body)
-            bar.update(itterator + 1)
-            # print("wrote {0}".format(itterator))
-            itterator = 1 + itterator
+            bar.update(iterator + 1)
+            # print("wrote {0}".format(iterator))
+            iterator = 1 + iterator
         bar.finish()
-        print("Finished writing csv file to database")
+        print("\nFinished writing csv file to database")
 
 
-def write_data(host, port, username, password, database, filename):
-    csv_file_to_db(host, port, username, password, database, filename)
+def write_data(host, port, username, password, database, filepath, measurement,
+               label_to_use, field_name_to_use, drop_db):
+    csv_file_to_db(host=host, port=port, username=username, password=password, database=database, filepath=filepath,
+                   measurement=measurement,label_to_use=label_to_use,
+                   field_name_to_use=field_name_to_use, drop_db=drop_db)

--- a/io_framework/csv_writer.py
+++ b/io_framework/csv_writer.py
@@ -47,7 +47,7 @@ class CsvWriter:
         self._database = database
 
     def data_to_csv_file(self, db_query, tags_to_drop=None, is_chunked=True, separator=',',
-                         new_csv_file_name='', measurement_to_use='per15min'):
+                         new_csv_file_name='', measurement_to_use=''):
         """
         Writes the new CSV file from scratch using the data that comes
         from client in the form of ResultSet. The file is stored in "resources" folder.
@@ -58,6 +58,8 @@ class CsvWriter:
         """
         if not new_csv_file_name:
             new_csv_file_name = self._csv_file_path
+        if not measurement_to_use:
+            measurement_to_use = self._measurement
         result_set = self._client.query(db_query, chunked=is_chunked)
         if 0 < len(result_set):
             df = result_set[measurement_to_use]

--- a/io_framework/csv_writer.py
+++ b/io_framework/csv_writer.py
@@ -8,7 +8,7 @@
 import pandas as pd
 from influxdb import DataFrameClient
 from influxdb import InfluxDBClient
-
+import os
 from io_framework.csv_file_to_db import write_data
 from resources.config import RESOURCES_DIR
 
@@ -38,7 +38,7 @@ class CsvWriter:
         """
         self._client = DataFrameClient(host, port, username, password, database)
         self._influxdb_client = InfluxDBClient(host, port, username, password, database)
-        self._csv_file_path = RESOURCES_DIR + "/" + new_cvs_file_name
+        self._csv_file_path = os.path.join(RESOURCES_DIR,new_cvs_file_name)
         self._measurement = new_measurement
         self._host = host
         self._port = port
@@ -46,7 +46,8 @@ class CsvWriter:
         self._password = password
         self._database = database
 
-    def data_to_csv_file(self, db_query, tags_to_drop=None, is_chunked=True, separator=',', new_csv_file_name=_csv_file_path):
+    def data_to_csv_file(self, db_query, tags_to_drop=None, is_chunked=True, separator=',',
+                         new_csv_file_name='', measurement_to_use='per15min'):
         """
         Writes the new CSV file from scratch using the data that comes
         from client in the form of ResultSet. The file is stored in "resources" folder.
@@ -55,9 +56,11 @@ class CsvWriter:
         :param is_chunked: is the data should be chunked
         :return: The success or failure
         """
+        if not new_csv_file_name:
+            new_csv_file_name = self._csv_file_path
         result_set = self._client.query(db_query, chunked=is_chunked)
         if 0 < len(result_set):
-            df = result_set[self._measurement]
+            df = result_set[measurement_to_use]
             if not isinstance(df, pd.DataFrame):
                 print("Error reading the data from database. Please test this query in Chronograf.")
                 return False
@@ -68,22 +71,16 @@ class CsvWriter:
         print("The database is empty. Nothing to save to CSV file.")
         return False
 
-    def csv_to_data(self, write_tags=None):
+    def csv_file_to_db(self, measurement_to_use='per15min', new_csv_file_name='',
+                       new_label_to_use='avg_hrcrx_max_byt', new_field_name_to_use='avg_hrcrx_max_byt', drop_db=False):
         """
-        Parses a CSV file and then writes it into the database.
-        :param write tags: that are written with the DataFrame to the DB.
+        Read the given csv file and write its content to database
+        :param measurement_to_use: choose a different measurement name for storing data
+        :return:
         """
-        # TODO error check and verify before writing.
-        # Add debug messages for a debug mode.
-        df = pd.read_csv(self._csv_file_path, index_col=0, parse_dates=[0])
-        df.dropna(axis=1, how='all', inplace=True)
-        df.fillna(value=0, inplace=True)
-        # df.reset_index().set_index('timestamps')
-        print("Reading csv file")
-        print(df.head())
-        self._client.write_points(df, measurement='per15min', protocol='json')
-        print('done')
-
-    def csv_file_to_db(self):
+        if not new_csv_file_name:
+            new_csv_file_name = self._csv_file_path
         write_data(host=self._host, port=self._port, username=self._username,
-                   password=self._password, database=self._database, filename=self._csv_file_path)
+                   password=self._password, database=self._database,
+                   filepath=new_csv_file_name, measurement=measurement_to_use,
+                   label_to_use=new_label_to_use, field_name_to_use=new_field_name_to_use, drop_db=drop_db)

--- a/tests/tester_csv_writer.py
+++ b/tests/tester_csv_writer.py
@@ -1,11 +1,9 @@
 from io_framework.csv_writer import CsvWriter
 from unittest import TestCase
-import pandas as pd
-from influxdb import DataFrameClient, InfluxDBClient
 from resources.config import RESOURCES_DIR
-import csv
 import os
 import filecmp
+
 
 class TesterCsvWriter(TestCase):
     _csv_file_path = None
@@ -29,6 +27,6 @@ class TesterCsvWriter(TestCase):
         test_csv_write3 = CsvWriter(self.host, self.port, self.username, self.password, self.database)
         test_csv_write3.csv_file_to_db()
         test_csv_write3.data_to_csv_file('select * from per15min', new_csv_file_name=data_return_path)
-        self.assertTrue(filecmp.cmp(data_return_path, initial_data_path,shallow=False),
+        self.assertTrue(filecmp.cmp(data_return_path, initial_data_path, shallow=False),
                         "Integration test failed, file is not the same")
         os.remove(data_return_path)


### PR DESCRIPTION
Fixes for cvs writer. Now file path, measurement, label and field name are not hardcoded.
Now the path to file should be cross platform, if passing a new path use os.path.join(RESOURCES_DIR,your_file_name).